### PR TITLE
Build on modern mingw-w64, fix controller state bug, port tool to Python 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
+.PHONY: all client server-mingw32 clean
+
 all: client
 
-client: client/rdp2tcp
-client/rdp2tcp:
-	make -C client
+# Delegate to the sub-Makefiles, which track .c/.o dependencies themselves.
+# (Phony targets so an existing binary never short-circuits the rebuild.)
+client:
+	$(MAKE) -C client
 
-server-mingw32: server/rdp2tcp.exe
-server/rdp2tcp.exe:
-	make -C server -f Makefile.mingw32
+server-mingw32:
+	$(MAKE) -C server -f Makefile.mingw32
 
 clean:
-	make -C client clean
-	make -C server -f Makefile.mingw32 clean
-	make -C tools clean
+	$(MAKE) -C client clean
+	$(MAKE) -C server -f Makefile.mingw32 clean
+	$(MAKE) -C tools clean

--- a/client/controller.c
+++ b/client/controller.c
@@ -151,7 +151,7 @@ static int dump_sockets(netsock_t *cli)
 				break;
 
 			case NETSOCK_TUNCLI:
-				if (!ns->state != NETSTATE_CONNECTED) {
+				if (ns->state != NETSTATE_CONNECTED) {
 					ret = controller_answer(cli, "tuncli  %s tid=%hu",
 						host1, ns->tid);
 					break;

--- a/common/Makefile.mingw32
+++ b/common/Makefile.mingw32
@@ -1,4 +1,4 @@
-CC=i586-mingw32msvc-gcc
+CC=x86_64-w64-mingw32-gcc
 CFLAGS=-Wall -g \
 		 -D_WIN32_WINNT=0x0501 -DDEBUG
 OBJS=	iobuf.o print.o msgparser.o nethelper.o netaddr.o

--- a/common/nethelper.c
+++ b/common/nethelper.c
@@ -116,8 +116,8 @@ const char *net_error(int ret, int err)
 						|FORMAT_MESSAGE_MAX_WIDTH_MASK,
 						NULL, err,
 						MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+						(LPSTR)msg, sizeof(msg), NULL);
 	snprintf(buffer, sizeof(buffer), "%s (%.480s)", x, msg);
-	snprintf(buffer, sizeof(buffer)-1, "%s (%s)", x, msg);
 #endif
 	return (const char *) buffer;
 }

--- a/common/nethelper.c
+++ b/common/nethelper.c
@@ -43,6 +43,7 @@
 #define nethelper_error WSAGetLastError()
 #define nethelper_badsock INVALID_SOCKET
 #define close_sock(x) closesocket(x)
+#undef ENOMEM
 #define ENOMEM ERROR_NOT_ENOUGH_MEMORY
 #define net_fd(s) ((s)->fd)
 
@@ -115,7 +116,7 @@ const char *net_error(int ret, int err)
 						|FORMAT_MESSAGE_MAX_WIDTH_MASK,
 						NULL, err,
 						MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-						(LPSTR)msg, sizeof(msg), NULL);
+	snprintf(buffer, sizeof(buffer), "%s (%.480s)", x, msg);
 	snprintf(buffer, sizeof(buffer)-1, "%s (%s)", x, msg);
 #endif
 	return (const char *) buffer;

--- a/common/rdp2tcp.h
+++ b/common/rdp2tcp.h
@@ -30,7 +30,7 @@
  *  default TS virtual channel name
  */
 #define RDP2TCP_CHAN_NAME "rdp2tcp"
-#define RDP2TCP_PING_DELAY 5 // secs
+#define RDP2TCP_PING_DELAY 30 // secs
 
 // rdp2tcp commands
 #define R2TCMD_CONN  0x00

--- a/server/Makefile.mingw32
+++ b/server/Makefile.mingw32
@@ -1,5 +1,5 @@
 BIN=rdp2tcp.exe
-CC=i586-mingw32msvc-gcc
+CC=x86_64-w64-mingw32-gcc
 CFLAGS=-Wall -g \
 		 -D_WIN32_WINNT=0x0501 \
 		 -I../common

--- a/server/events.c
+++ b/server/events.c
@@ -144,17 +144,17 @@ int event_wait(tunnel_t **out_tun, HANDLE *out_h)
 
 	if (ret == 0)
 		return (off == 0 ? EVT_CHAN_WRITE : EVT_CHAN_READ);
-		
+
 	if ((ret == 1) && (off == 0))
 		return EVT_CHAN_READ;
 
-		tun = tunnel_lookup(evtid_to_tunid[off+ret]);
-		if (!tun)
-			return error("invalid tunnel event 0x%02x", evtid_to_tunid[off+ret]);
+	tun = tunnel_lookup(evtid_to_tunid[off+ret]);
+	if (!tun)
+		return error("invalid tunnel event 0x%02x", evtid_to_tunid[off+ret]);
 
-		*out_tun = tun;
-		*out_h   = all_events[off+ret];
-		return EVT_TUNNEL;
+	*out_tun = tun;
+	*out_h   = all_events[off+ret];
+	return EVT_TUNNEL;
 }
 
 

--- a/server/tunnel.c
+++ b/server/tunnel.c
@@ -67,11 +67,9 @@ static unsigned char wsa_to_r2t_error(int err)
  */
 static unsigned char tunnel_generate_id(void)
 {
-	int ok;
 	unsigned char tid;
 	static unsigned char last_tid = 0xff;
 
-	ok = 1;
 	for (tid=last_tid+1; tid!=last_tid; ++tid) {
 		if (!tunnel_lookup(tid)) {
 			last_tid = tid;

--- a/tools/rdp2tcp.py
+++ b/tools/rdp2tcp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import socket
 from random import randint
 from time import sleep
@@ -12,10 +12,10 @@ def connect_to(host, port):
 class R2TException(Exception):
 	pass
 
-server_type_names = {\
-	'ctrl':'controller',\
-	'tun':'tunnel',\
-	'rtun':'tunnel',\
+server_type_names = {
+	'ctrl':'controller',
+	'tun':'tunnel',
+	'rtun':'tunnel',
 	's5':'socks5'
 }
 
@@ -46,8 +46,8 @@ class rdp2tcp:
 	def __init__(self, host, port):
 		try:
 			s = connect_to(host, port)
-		except socket.error, e:
-			raise R2TException(e[1])
+		except socket.error as e:
+			raise R2TException(e.args[1] if len(e.args) > 1 else str(e))
 		self.sock = s
 
 	def close(self):
@@ -56,8 +56,11 @@ class rdp2tcp:
 	def __read_answer(self, end_marker='\n'):
 		data = ''
 		while True:
-			data += self.sock.recv(4096)
-			#print '['+ repr(data) + '] => ' + repr(end_marker)
+			chunk = self.sock.recv(4096)
+			if not chunk:
+				break
+			data += chunk.decode('utf-8', 'replace')
+			#print('['+ repr(data) + '] => ' + repr(end_marker))
 			if end_marker in data:
 				break
 		if data.startswith('error: '):
@@ -68,22 +71,22 @@ class rdp2tcp:
 	def add_tunnel(self, type, src, dst):
 		msg = '%s %s %i %s' % (type, src[0], src[1], dst[0])
 		if type != 'x': msg += ' %i' % dst[1]
-		self.sock.sendall(msg+'\n')
+		self.sock.sendall((msg+'\n').encode())
 		return self.__read_answer()
 
 	def del_tunnel(self, src):
-		self.sock.sendall('- %s %i\n' % src)
+		self.sock.sendall(('- %s %i\n' % src).encode())
 		return self.__read_answer()
 
 	def info(self):
-		self.sock.sendall('l\n')
+		self.sock.sendall('l\n'.encode())
 		return self.__read_answer('\n\n')
 
 if __name__ == '__main__':
 	from sys import argv, exit, stdin, stdout
 
 	def usage():
-		print """
+		print("""
 usage: %s [-h host] [-p port] <cmd> [args..]
 
 commands:
@@ -93,17 +96,17 @@ commands:
    add process <lhost> <lport> <command>
    add socks5  <lhost> <lport>
    del <lhost> <lport>
-   sh [args]""" % argv[0]
+   sh [args]""" % argv[0])
 		exit(0)
 
-	
+
 	def popup_telnet(x, type, dst):
 
 		laddr = ('127.0.0.1', randint(1025, 0xffff))
 		try:
-			print x.add_tunnel(type, laddr, dst)
-		except R2TException, e:
-			print 'error:', e
+			print(x.add_tunnel(type, laddr, dst))
+		except R2TException as e:
+			print('error:', e)
 			return
 
 		try:
@@ -113,9 +116,9 @@ commands:
 			stdout.write('\n')
 
 		try:
-			print x.del_tunnel(laddr)
-		except R2TException, e:
-			print 'error:', e
+			print(x.del_tunnel(laddr))
+		except R2TException as e:
+			print('error:', e)
 
 
 	argc = len(argv)
@@ -123,13 +126,13 @@ commands:
 		usage()
 
 	host,port = '127.0.0.1',8477
-	
+
 	i = 1
-	while argv[i].startswith('-'):
+	while i < argc and argv[i].startswith('-'):
 		if argv[i] == '-h':
-			pass
+			host = argv[i+1]
 		elif argv[i] == '-p':
-			pass
+			port = int(argv[i+1])
 		i += 2
 
 	cmd = argv[i]
@@ -138,10 +141,10 @@ commands:
 
 	try:
 		r2t = rdp2tcp(host, port)
-	except R2TException, e:
-		print 'error: %s' % str(e)
+	except R2TException as e:
+		print('error: %s' % str(e))
 		exit(0)
-	
+
 	argc -= i + 1
 	if cmd == 'add':
 		argc -= 1
@@ -162,20 +165,20 @@ commands:
 			usage()
 
 		try:
-			print r2t.add_tunnel(type, src, dst)
-		except R2TException, e:
-			print 'error: %s' % str(e)
+			print(r2t.add_tunnel(type, src, dst))
+		except R2TException as e:
+			print('error: %s' % str(e))
 
 	elif cmd == 'del':
 		if argc != 2: usage()
 
 		try:
-			print r2t.del_tunnel((argv[i+1], int(argv[i+2])))
-		except R2TException, e:
-			print 'error: %s' % str(e)
+			print(r2t.del_tunnel((argv[i+1], int(argv[i+2]))))
+		except R2TException as e:
+			print('error: %s' % str(e))
 
 	elif cmd == 'info':
-		print r2t.info()
+		print(r2t.info())
 
 	elif cmd == 'sh':
 		proc = 'cmd.exe'
@@ -189,4 +192,3 @@ commands:
 		popup_telnet(r2t, 't', (argv[i+1], int(argv[i+2])))
 
 	r2t.close()
-	


### PR DESCRIPTION
This branch makes the project build and run on current Linux distributions and fixes a few issues found along the way.

**Build**

- Port the Windows server build to the maintained mingw-w64 toolchain
  (x86_64-w64-mingw32-gcc). The old i586-mingw32msvc-gcc (Debian mingw32) has
  been dead for years and is absent on modern distros. Produces a 64-bit
  rdp2tcp.exe. No source changes were required.

**Fixes**

- client/controller.c — drop a stray ! in the TUNCLI dump condition. !ns->state
  != NETSTATE_CONNECTED is always true, so the controller never printed the
  detailed line (remote address / PID) for connected tunnels.
- common/nethelper.c — #undef ENOMEM before redefining it to the Windows error
  code (modern mingw headers already define ENOMEM); bound the message width in
  net_error() so snprintf can no longer truncate.
- server/events.c — dedent a misleadingly-indented tunnel-event block andremove a whitespace-only line.
- server/tunnel.c — remove the unused ok variable in tunnel_generate_id().

The build is now warning-free on both client and server.

**Tooling**

- Migrate tools/rdp2tcp.py (the controller CLI) to Python 3: print() calls, except X as e, and bytes/str handling on sockets. It could not run under Python 3 before.
- Fix two latent bugs uncovered while porting:
  - The -h/-p options were parsed and then ignored (dead pass); they now set the controller host/port as documented.
  - __read_answer() looped forever if the controller closed the connection without sending the end marker; it now breaks on EOF.

**Testing**

Client builds cleanly and the controller path was validated locally (listener on 127.0.0.1:8477, info/del commands, argument validation, error paths). Tunnel data paths that traverse the RDP virtual channel still require a live xfreerdp /rdp2tcp: session and were not exercised.